### PR TITLE
fix(decorators): export decorators

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './sqs.module';
 export * from './sqs.service';
+export * from './sqs.decorators';


### PR DESCRIPTION
Decorators were not being exported. So when I was following the readme to simply decorate my message-handling methods, there was of course an error. I can skirt around this by referencing the file-structure of the module for now, but this PR is a permanent change to fix this.