### PR TITLE
Add more than one event listener to consumers

### DIFF
--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -50,12 +50,14 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
           : { handleMessage: metadata.discoveredMethod.handler.bind(metadata.discoveredMethod.parentClass.instance) }),
       });
 
-      const eventMetadata = eventHandlers.find(({ meta }) => meta.name === name);
-      if (eventMetadata) {
-        consumer.addListener(
-          eventMetadata.meta.eventName,
-          eventMetadata.discoveredMethod.handler.bind(metadata.discoveredMethod.parentClass.instance),
-        );
+      const eventsMetadata = eventHandlers.filter(({ meta }) => meta.name === name);
+      for (const eventMetadata of eventsMetadata) {
+        if (eventMetadata) {
+          consumer.addListener(
+            eventMetadata.meta.eventName,
+            eventMetadata.discoveredMethod.handler.bind(metadata.discoveredMethod.parentClass.instance),
+          );
+        }
       }
       this.consumers.set(name, consumer);
     });


### PR DESCRIPTION
Events from sqs-consumer:

_"Each consumer is an EventEmitter and emits the following events:
processing_error, timeout_error, message_received, message_processed, response_processed, stopped, empty"_

https://github.com/BBC/sqs-consumer#events