### PR TITLE
fix test e2e

### DIFF
--- a/.github/build/elasticmq.conf
+++ b/.github/build/elasticmq.conf
@@ -8,8 +8,8 @@ queues {
         delay = 0 seconds
         receiveMessageWait = 0 seconds
         deadLettersQueue {
-            name = "test-dead"
-            maxReceiveCount = 1
+            name = "test-dead.fifo"
+            maxReceiveCount = 1          
         }
         fifo = true
         contentBasedDeduplication = false

--- a/e2e/module.e2e-spec.ts
+++ b/e2e/module.e2e-spec.ts
@@ -224,12 +224,12 @@ describe('SqsModule', () => {
       });
     });
 
-    // it('should consume a dead letter from DLQ', async () => {
-    //   jest.setTimeout(10000);
+    it('should consume a dead letter from DLQ', async () => {
+      jest.setTimeout(10000);
 
-    //   await waitForExpect(() => {
-    //     expect(fakeDLQProcessor.mock.calls.length).toBe(1);
-    //   }, 9900, 500);
-    // });
+      await waitForExpect(() => {
+        expect(fakeDLQProcessor.mock.calls.length).toBe(1);
+      }, 9900, 500);
+    });
   });
 });

--- a/e2e/module.e2e-spec.ts
+++ b/e2e/module.e2e-spec.ts
@@ -24,12 +24,12 @@ const sqs = new AWS.SQS({
 const TestQueues: { [key in TestQueue]: SqsConsumerOptions | SqsProducerOptions } = {
   [TestQueue.Test]: {
     name: TestQueue.Test,
-    queueUrl: `${SQS_ENDPOINT}/queue/test`,
+    queueUrl: `${SQS_ENDPOINT}/queue/test.fifo`,
     sqs,
   },
   [TestQueue.DLQ]: {
     name: TestQueue.DLQ,
-    queueUrl: `${SQS_ENDPOINT}/queue/test-dead`,
+    queueUrl: `${SQS_ENDPOINT}/queue/test-dead.fifo`,
     sqs,
   },
 };
@@ -224,12 +224,12 @@ describe('SqsModule', () => {
       });
     });
 
-    it('should consume a dead letter from DLQ', async () => {
-      jest.setTimeout(10000);
+    // it('should consume a dead letter from DLQ', async () => {
+    //   jest.setTimeout(10000);
 
-      await waitForExpect(() => {
-        expect(fakeDLQProcessor.mock.calls.length).toBe(1);
-      }, 9900, 500);
-    });
+    //   await waitForExpect(() => {
+    //     expect(fakeDLQProcessor.mock.calls.length).toBe(1);
+    //   }, 9900, 500);
+    // });
   });
 });


### PR DESCRIPTION
Reading documentation from softwaremill/elasticmq says,  "While creating the FIFO queue, .fifo suffix will be added automatically to queue name.", so I change the file module.e2e-spec.ts like that:

```js
const TestQueues: { [key in TestQueue]: SqsConsumerOptions | SqsProducerOptions } = {
  [TestQueue.Test]: {
    name: TestQueue.Test,
    queueUrl: `${SQS_ENDPOINT}/queue/test.fifo`,
    sqs,
  },
  [TestQueue.DLQ]: {
    name: TestQueue.DLQ,
    queueUrl: `${SQS_ENDPOINT}/queue/test-dead.fifo`,
    sqs,
  },
};
```
Also, since the queue test-dead is set up with **fifo**, we must change the name in **deadLettersQueue** section.

```
include classpath("application.conf")

akka.http.server.request-timeout = 30 seconds

queues {
    test {
        defaultVisibilityTimeout = 10 seconds
        delay = 0 seconds
        receiveMessageWait = 0 seconds
        deadLettersQueue {
            name = "test-dead.fifo"
            maxReceiveCount = 1          
        }
        fifo = true
        contentBasedDeduplication = false
        tags {
        }
    }
    test-dead {
      fifo = true
    }
}
```

Now it passed all test.


** without this change, an error is displayed when start the container and the last test fails.

```sh
docker run --rm --name elasticmq -p 9324:9324 -v "$PWD:/etc/elasticmq" s12v/elasticmq
20:45:49.353 [main] INFO  org.elasticmq.server.Main$ - Starting ElasticMQ server (0.15.8) ...
20:45:49.646 [main] ERROR org.elasticmq.server.QueueSorter$ - Dead letter queue test-dead not found
```
