### PR TITLE
Support NestJS 8 peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "wait-for-expect": "^3.0.2"
   },
   "peerDependencies": {
-    "@nestjs/common": "^6.10.11 || ^7.0.0",
-    "@nestjs/core": "^6.10.11 || ^7.0.0"
+    "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0",
+    "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0"
   }
 }


### PR DESCRIPTION
Install fails on NestJS 8 because of old peer dependencies.