### PR TITLE
switch @nestjs-plus/discovery to @golevelup/nestjs-discovery

### DIFF
--- a/lib/sqs.module.ts
+++ b/lib/sqs.module.ts
@@ -2,7 +2,7 @@ import { DynamicModule, Global, Module, Provider, Type } from '@nestjs/common';
 import { SqsService } from './sqs.service';
 import { SqsModuleAsyncOptions, SqsModuleOptionsFactory, SqsOptions } from './sqs.types';
 import { SQS_OPTIONS } from './sqs.constants';
-import { DiscoveryModule, DiscoveryService } from '@nestjs-plus/discovery';
+import { DiscoveryModule, DiscoveryService } from '@golevelup/nestjs-discovery';
 
 @Global()
 @Module({

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -3,7 +3,7 @@ import { Consumer } from 'sqs-consumer';
 import { Producer } from 'sqs-producer';
 import { SQSClient, GetQueueAttributesCommand, PurgeQueueCommand, QueueAttributeName } from '@aws-sdk/client-sqs';
 import { Message, QueueName, SqsConsumerEventHandlerMeta, SqsMessageHandlerMeta, SqsOptions } from './sqs.types';
-import { DiscoveryService } from '@nestjs-plus/discovery';
+import { DiscoveryService } from '@golevelup/nestjs-discovery';
 import { SQS_CONSUMER_EVENT_HANDLER, SQS_CONSUMER_METHOD, SQS_OPTIONS } from './sqs.constants';
 
 @Injectable()

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Suhun Han <ssut@ssut.me>",
   "license": "MIT",
   "dependencies": {
-    "@nestjs-plus/discovery": "^2.0.2",
+    "@golevelup/nestjs-discovery": "^3.0.0",
     "sqs-consumer": "^7.0.3",
     "sqs-producer": "^3.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,12 +1,16 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@aws-sdk/client-sqs':
     specifier: ^3.321.1
     version: 3.321.1
-  '@nestjs-plus/discovery':
-    specifier: ^2.0.2
-    version: 2.0.2
+  '@golevelup/nestjs-discovery':
+    specifier: ^3.0.0
+    version: 3.0.0
   sqs-consumer:
     specifier: ^7.0.3
     version: 7.0.3(@aws-sdk/client-sqs@3.321.1)
@@ -1165,6 +1169,12 @@ packages:
       - supports-color
     dev: true
 
+  /@golevelup/nestjs-discovery@3.0.0:
+    resolution: {integrity: sha512-ZvkXtobTKxXB1LJanP/l6Z/Fing88IMBr3uabQpU2IWjfsstjh02qYDSU2cfD6CSmNldX5ewW5Pd+SdK2lU8Sw==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
+
   /@humanwhocodes/config-array@0.5.0:
     resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
     engines: {node: '>=10.10.0'}
@@ -1448,10 +1458,6 @@ packages:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
     dev: true
-
-  /@nestjs-plus/discovery@2.0.2:
-    resolution: {integrity: sha512-7cOA00gFFbDj6DgWmCD6gXEOKUHs4fn/qBTB4yq7APkWVXKhF3+92D7MKLfpZstFAlKapdDu25c+Ed0ZUKIoGA==}
-    dev: false
 
   /@nestjs/common@9.4.0(reflect-metadata@0.1.13)(rxjs@7.8.1):
     resolution: {integrity: sha512-RUcVAQsEF4WPrmzFXEOUfZnPwrLTe1UVlzXTlSyfqfqbdWDPKDGlIPVelBLfc5/+RRUQ0I5iE4+CQvpCmkqldw==}
@@ -3875,7 +3881,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}


### PR DESCRIPTION
Closes https://github.com/ssut/nestjs-sqs/issues/53

This lib uses the [@nestjs-plus/discovery](https://github.com/michaelkrone/nestjs-plus) package, which is a fork of the [@golevelup/nestjs-discovery](https://github.com/golevelup/nestjs/tree/master/packages/discovery)  package.

The fork hasn't been updated since 4 years, and the bug that it originally fixes isn't a problem anymore in the original package.

So this PR reverts it back, giving us a more updated / maintained version of the lib.

**Additional information:**
The original issue fixed by the fork (see [relative commits](https://github.com/golevelup/nestjs/compare/master...michaelkrone:nestjs-plus:master) seems to be fixed in the original repository [here](https://github.com/golevelup/nestjs/blob/master/packages/discovery/src/discovery.service.ts#L44)