### PR TITLE
[ERROR] Fix exception when no message handler is registered.

### DIFF
--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -37,6 +37,7 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
       const metadata = messageHandlers.find(({ meta }) => meta.name === name);
       if (!metadata) {
         this.logger.warn(`No metadata found for: ${name}`);
+        return;
       }
 
       const isBatchHandler = metadata.meta.batch === true;


### PR DESCRIPTION
When no metadata is found for a handler, it should return early from the setup, rather than printing a warning and attempting to continue, which immediately causes errors and can prevent the logger from displaying the warning, depending on logger setup. 