### PR TITLE
feat: add support for consumer stop options

### DIFF
--- a/lib/sqs.types.ts
+++ b/lib/sqs.types.ts
@@ -1,4 +1,4 @@
-import type { ConsumerOptions } from 'sqs-consumer';
+import type { ConsumerOptions, StopOptions } from 'sqs-consumer';
 import type { Producer } from 'sqs-producer';
 import type { LoggerService, ModuleMetadata, Type } from '@nestjs/common';
 import type { MessageAttributeValue } from '@aws-sdk/client-sqs';
@@ -18,6 +18,7 @@ export interface SqsOptions {
   consumers?: SqsConsumerOptions[];
   producers?: SqsProducerOptions[];
   logger?: LoggerService;
+  globalStopOptions?: StopOptions;
 }
 
 export interface SqsModuleOptionsFactory {

--- a/lib/sqs.types.ts
+++ b/lib/sqs.types.ts
@@ -1,4 +1,4 @@
-import type { ConsumerOptions, StopOptions } from 'sqs-consumer';
+import type { Consumer, ConsumerOptions, StopOptions } from 'sqs-consumer';
 import type { Producer } from 'sqs-producer';
 import type { LoggerService, ModuleMetadata, Type } from '@nestjs/common';
 import type { MessageAttributeValue } from '@aws-sdk/client-sqs';
@@ -8,6 +8,12 @@ export type QueueName = string;
 
 export type SqsConsumerOptions = Omit<ConsumerOptions, 'handleMessage' | 'handleMessageBatch'> & {
   name: QueueName;
+  stopOptions?: StopOptions;
+};
+
+export type SqsConsumerMapValues = {
+  instance: Consumer;
+  stopOptions: StopOptions;
 };
 
 export type SqsProducerOptions = ProducerOptions & {


### PR DESCRIPTION
## Context
The `bbc/sqs-consumer` library gives support for [stop options](https://github.com/bbc/sqs-consumer/blob/2e92e6fede75b348870ef8e3289bd2df2ec1a393/src/consumer.ts#L130), where it's possible to [abort immediately a consumer](https://github.com/bbc/sqs-consumer/blob/2e92e6fede75b348870ef8e3289bd2df2ec1a393/src/consumer.ts#L144-L148) without await for [polling to complete](https://github.com/bbc/sqs-consumer/blob/2e92e6fede75b348870ef8e3289bd2df2ec1a393/src/consumer.ts#L151). 

## Problem
Currently, the `ssut/nestjs-sqs` doesn't give support to set these options and [call stop method without any params](https://github.com/ssut/nestjs-sqs/blob/0cfb34053c9ca3b9ad9c60cc86a9275b357fc4dd/lib/sqs.service.ts#L84). Abort behaviour is an important option in a graceful shutdown strategy and it would be a good improvement for the lib support that too.

## Solution
The stop options can be used in a global and / or consumer specific approach:

1. Used for all consumers: `globalStopOptions`
Enable stopping of all registered consumers immediately after shutdown.
```ts
@Module({
  imports: [
    SqsModule.register({
      consumers: [
        {
          name: 'queue-1',
          queueUrl: "http://localhost:9324/queue/queue-1.fifo",
        },
        {
          name: 'queue-2',
          queueUrl: "http://localhost:9324/queue/queue-2.fifo",
        }
      ],
      producers: [],
      globalStopOptions: {
        abort: true,
      }
    }),
  ],
})
class AppModule {}
```
2. Used for specific consumer: `stopOptions`
Enable stopping of specific consumers immediately after shutdown.
```ts
@Module({
  imports: [
    SqsModule.register({
      consumers: [
        {
          name: 'queue-1',
          queueUrl: "http://localhost:9324/queue/queue-1.fifo",
          stopOptions: {
            abort: true,
          },
        },
        {
          name: 'queue-2',
          queueUrl: "http://localhost:9324/queue/queue-2.fifo",
        }
      ],
      producers: []
    }),
  ],
})
class AppModule {}
```
3. Used for all consumers with consumer specific override: `globalStopOptions` + `stopOptions`
Enable stopping of all registered consumers immediately after shutdown, except consumer `queue-1` because its `stopOptions` override the `globalStopOptions`.
```ts
@Module({
  imports: [
    SqsModule.register({
      consumers: [
        {
          name: 'queue-1',
          queueUrl: "http://localhost:9324/queue/queue-1.fifo",
          stopOptions: {
            abort: false,
          },
        },
        {
          name: 'queue-2',
          queueUrl: "http://localhost:9324/queue/queue-2.fifo",
        }
      ],
      producers: [],
      globalStopOptions: {
        abort: true,
      }
    }),
  ],
})
class AppModule {}
```
⚠️ **Important**: I was unable to add any tests because I had problems running the tests locally.