### PR TITLE
fix(SqsService): getQueueInfo method return the correct consumer instance

### DIFF
--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -99,7 +99,7 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
       throw new Error(`Consumer/Producer does not exist: ${name}`);
     }
 
-    const { sqs, queueUrl } = (this.consumers.get(name) ?? this.producers.get(name)) as {
+    const { sqs, queueUrl } = (this.consumers.get(name).instance ?? this.producers.get(name)) as {
       sqs: SQSClient;
       queueUrl: string;
     };


### PR DESCRIPTION
## Description
I've identified an issue in the getQueueInfo method within the SqsService class after trying to use the library's latest commit, which includes the abort stop feature.
The consumer instance wasn't being returned correctly following recent modifications. This pull request addresses this discrepancy, ensuring the accurate retrieval of the consumer instance.
Additionally, I'm pleased to report that all automated tests now pass seamlessly 😄 