### PR TITLE
feat: add globalOptions support in SqsService with sqs endpoint property

### DIFF
--- a/e2e/module.e2e-spec.ts
+++ b/e2e/module.e2e-spec.ts
@@ -66,6 +66,29 @@ describe('SqsModule', () => {
       expect(sqsService.options.consumers).toHaveLength(1);
       expect(sqsService.options.producers).toHaveLength(1);
     });
+
+    it('should register module async with globalOptions', async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          SqsModule.registerAsync({
+            useFactory: async () => {
+              return {
+                globalOptions: {
+                  endpoint: SQS_ENDPOINT,
+                },
+                consumers: [TestQueues[TestQueue.Test]],
+                producers: [TestQueues[TestQueue.Test]],
+              };
+            },
+          }),
+        ],
+      }).compile();
+
+      const sqsService = module.get(SqsService);
+      expect(sqsService).toBeTruthy();
+      expect(sqsService.options.consumers).toHaveLength(1);
+      expect(sqsService.options.producers).toHaveLength(1);
+    });
   });
 
   describe('full flow', () => {

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -29,8 +29,8 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
   ) {}
 
   public async onModuleInit(): Promise<void> {
-    this.globalOptions = this.options.globalOptions ?? {};
     this.logger = this.options.logger ?? new Logger('SqsService', { timestamp: false });
+    this.globalOptions = this.options.globalOptions ?? {};
     this.globalStopOptions = this.options.globalStopOptions ?? {};
 
     const messageHandlers = await this.discover.providerMethodsWithMetaAtKey<SqsMessageHandlerMeta>(

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -52,10 +52,11 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
+      const shouldUseGlobalEndpoint = this.globalOptions.endpoint && !consumerOptions.sqs;
       const isBatchHandler = metadata.meta.batch === true;
       const consumer = Consumer.create({
         ...consumerOptions,
-        ...(this.globalOptions.endpoint && {
+        ...(shouldUseGlobalEndpoint && {
           sqs: new SQSClient({
             endpoint: this.globalOptions.endpoint,
           }),
@@ -87,7 +88,15 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
         throw new Error(`Producer already exists: ${name}`);
       }
 
-      const producer = Producer.create(producerOptions);
+      const shouldUseGlobalEndpoint = this.globalOptions.endpoint && !producerOptions.sqs;
+      const producer = Producer.create({
+        ...producerOptions,
+        ...(shouldUseGlobalEndpoint && {
+          sqs: new SQSClient({
+            endpoint: this.globalOptions.endpoint,
+          }),
+        }),
+      });
       this.producers.set(name, producer);
     });
 

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -52,11 +52,11 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
         return;
       }
 
-      const shouldUseGlobalEndpoint = this.globalOptions.endpoint && !consumerOptions.sqs;
+      const shouldUseGlobalOptionsEndpoint = this.globalOptions.endpoint && !consumerOptions.sqs;
       const isBatchHandler = metadata.meta.batch === true;
       const consumer = Consumer.create({
         ...consumerOptions,
-        ...(shouldUseGlobalEndpoint && {
+        ...(shouldUseGlobalOptionsEndpoint && {
           sqs: new SQSClient({
             endpoint: this.globalOptions.endpoint,
           }),
@@ -88,10 +88,10 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
         throw new Error(`Producer already exists: ${name}`);
       }
 
-      const shouldUseGlobalEndpoint = this.globalOptions.endpoint && !producerOptions.sqs;
+      const shouldUseGlobalOptionsEndpoint = this.globalOptions.endpoint && !producerOptions.sqs;
       const producer = Producer.create({
         ...producerOptions,
-        ...(shouldUseGlobalEndpoint && {
+        ...(shouldUseGlobalOptionsEndpoint && {
           sqs: new SQSClient({
             endpoint: this.globalOptions.endpoint,
           }),

--- a/lib/sqs.types.ts
+++ b/lib/sqs.types.ts
@@ -25,7 +25,7 @@ export type GlobalOptions = {
 };
 
 export interface SqsOptions {
-  globalOptions: GlobalOptions;
+  globalOptions?: GlobalOptions;
   consumers?: SqsConsumerOptions[];
   producers?: SqsProducerOptions[];
   logger?: LoggerService;

--- a/lib/sqs.types.ts
+++ b/lib/sqs.types.ts
@@ -20,7 +20,12 @@ export type SqsProducerOptions = ProducerOptions & {
   name: QueueName;
 };
 
+export type GlobalOptions = {
+  endpoint?: string;
+};
+
 export interface SqsOptions {
+  globalOptions: GlobalOptions;
   consumers?: SqsConsumerOptions[];
   producers?: SqsProducerOptions[];
   logger?: LoggerService;


### PR DESCRIPTION
### Context
Related issue: [Issue #78](https://github.com/ssut/nestjs-sqs/issues/78).

### Problem
Currently, we're unable to set the SQS endpoint when the module is registered. As mentioned in the issue, when using an emulator, we receive warnings because the `queueUrl` is composed from AWS credentials in the environment, which differs from local URLs such as those used by LocalStack.

```
QueueUrl=https://localhost.localstack.cloud:4566/000000000000/iam_sync-user-queue differs from SQSClient resolved endpoint=https://sqs.us-east-1.amazonaws.com/, using QueueUrl host as endpoint.
Set [endpoint=string] or [useQueueUrlAsEndpoint=false] on the SQSClient
```

The error message suggests using the `useQueueUrlAsEndpoint` property, but I couldn't find that in the SQSClient options. However, setting the `endpoint` directly resolves the issue. 

To provide more background, when running SQS locally using LocalStack, I set the SQS endpoint to `http://localhost:4566`.

### Solution
I added an optional `globalOptions` object property with an `endpoint` field to allow setting the endpoint directly on the SQSClient. The condition ensures that if the consumer/producer options have an `sqs` property, it won't be overwritten by the global one. I decided that consumer/producer options should take priority.

This solution was tested locally and works as expected.

### Other Thoughts
We can discuss adding more properties to the `globalOptions`. I'm open to suggestions, but for now, I wasn't sure if anything else would be necessary.

