### PR TITLE
fix(SqsService): getQueueInfo() - cannot read properties of undefined (reading 'instance')

### DIFF
--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -97,7 +97,7 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
       throw new Error(`Consumer/Producer does not exist: ${name}`);
     }
 
-    const { sqs, queueUrl } = (this.consumers.get(name).instance ?? this.producers.get(name)) as {
+    const { sqs, queueUrl } = (this.consumers.get(name)?.instance ?? this.producers.get(name)) as {
       sqs: SQSClient;
       queueUrl: string;
     };


### PR DESCRIPTION
Consumer might not be exists. It causes following error:
```
TypeError: Cannot read properties of undefined (reading 'instance')
```

#### Caused by
- https://github.com/ssut/nestjs-sqs/pull/77