### PR TITLE
feat: add ConfigService support for dynamic queue name resolution

### DIFF
--- a/e2e/module.e2e-spec.ts
+++ b/e2e/module.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { Message, SQSClient } from '@aws-sdk/client-sqs';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Module } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { vi } from 'vitest';
 import { beforeAll } from 'vitest';
@@ -11,11 +11,13 @@ import { afterEach } from 'vitest';
 import { SqsModule, SqsService } from '../lib';
 import { SqsConsumerEventHandler, SqsMessageHandler } from '../lib/sqs.decorators';
 import { SqsConsumerOptions, SqsProducerOptions } from '../lib/sqs.types';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 const SQS_ENDPOINT = process.env.SQS_ENDPOINT || 'http://localhost:9324/000000000000';
 
 enum TestQueue {
   Test = 'test',
+  Test2 = 'test2',
   DLQ = 'test-dead',
 }
 
@@ -32,12 +34,48 @@ const TestQueues: { [key in TestQueue]: SqsConsumerOptions | SqsProducerOptions 
     queueUrl: `${SQS_ENDPOINT}/test.fifo`,
     sqs,
   },
+  [TestQueue.Test2]: {
+    name: TestQueue.Test2,
+    queueUrl: `${SQS_ENDPOINT}/test2.fifo`,
+    sqs,
+  },
   [TestQueue.DLQ]: {
     name: TestQueue.DLQ,
     queueUrl: `${SQS_ENDPOINT}/test-dead.fifo`,
     sqs,
   },
 };
+
+enum ENV_KEYS {
+  TestQueue = 'test_queue',
+  Test2Queue = 'test2_queue',
+  DLQ = 'dlq',
+}
+
+class MockConfigService {
+  private readonly CONFIG: Record<ENV_KEYS, TestQueue> = {
+    test_queue: TestQueue.Test,
+    test2_queue: TestQueue.Test2,
+    dlq: TestQueue.DLQ,
+  };
+
+  getOrThrow(key: ENV_KEYS) {
+    if (!this.CONFIG[key]) throw new Error(`Config key not found: ${key}`);
+    return this.CONFIG[key];
+  }
+}
+
+@Module({
+  providers: [
+    {
+      provide: ConfigService,
+      useClass: MockConfigService,
+    }
+  ],
+  exports: [ConfigService]
+})
+class MockConfigServiceModule { }
+
 
 describe('SqsModule', () => {
   let module: TestingModule;
@@ -77,7 +115,7 @@ describe('SqsModule', () => {
 
     @Injectable()
     class A {
-      public constructor(public readonly sqsService: SqsService) {}
+      public constructor(public readonly sqsService: SqsService) { }
 
       @SqsMessageHandler(TestQueue.Test)
       public async handleTestMessage(message: Message) {
@@ -90,6 +128,26 @@ describe('SqsModule', () => {
       }
 
       @SqsMessageHandler(TestQueue.DLQ)
+      public async handleDLQMessage(message: Message) {
+        fakeDLQProcessor(message);
+      }
+    }
+
+    @Injectable()
+    class B {
+      constructor(public readonly sqsService: SqsService) { }
+
+      @SqsMessageHandler({ configKey: ENV_KEYS.Test2Queue })
+      public async handleTestMessage(message: Message) {
+        fakeProcessor(message);
+      }
+
+      @SqsConsumerEventHandler({ name: TestQueue.Test }, 'processing_error')
+      public handleErrorEvent(err: Error, message: Message) {
+        fakeErrorEventHandler(err, message);
+      }
+
+      @SqsMessageHandler({ configKey: ENV_KEYS.DLQ })
       public async handleDLQMessage(message: Message) {
         fakeDLQProcessor(message);
       }
@@ -108,19 +166,25 @@ describe('SqsModule', () => {
                 messageAttributeNames: ['All'],
               },
               {
+                ...TestQueues[TestQueue.Test2],
+                waitTimeSeconds: 1,
+                batchSize: 3,
+                terminateVisibilityTimeout: true,
+                messageAttributeNames: ['All'],
+              },
+              {
                 ...TestQueues[TestQueue.DLQ],
                 waitTimeSeconds: 1,
               },
             ],
             producers: [
-              {
-                ...TestQueues[TestQueue.Test],
-              },
+              TestQueues[TestQueue.Test],
+              TestQueues[TestQueue.Test2],
             ],
           }),
         ],
-        providers: [A],
-      }).compile();
+        providers: [A, B],
+      }).overrideModule(ConfigModule).useModule(MockConfigServiceModule).compile();
       await module.init();
 
       const sqsService = module.get(SqsService);
@@ -231,6 +295,32 @@ describe('SqsModule', () => {
         }
       });
     }, 5000);
+
+    it('should register and call a handler using configKey', async () => {
+      const sqsService = module.get(SqsService);
+      const id = String(Math.floor(Math.random() * 1000000));
+
+      await new Promise<void>(async (resolve, reject) => {
+        try {
+          fakeProcessor.mockImplementation((message) => {
+            expect(message).toBeTruthy();
+            expect(JSON.parse(message.Body)).toStrictEqual({ test: true });
+            resolve();
+          });
+
+          await sqsService.send(TestQueue.Test2, {
+            id,
+            body: { test: true },
+            delaySeconds: 0,
+            groupId: 'test',
+            deduplicationId: id,
+          });
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
 
     it('should consume a dead letter from DLQ', async () => {
       await vi.waitFor(

--- a/lib/sqs.decorators.ts
+++ b/lib/sqs.decorators.ts
@@ -1,6 +1,8 @@
 import { SetMetadata } from '@nestjs/common';
 import { SQS_CONSUMER_EVENT_HANDLER, SQS_CONSUMER_METHOD } from './sqs.constants';
+import { QueueNameArgument } from './sqs.types';
 
-export const SqsMessageHandler = (name: string, batch?: boolean) => SetMetadata(SQS_CONSUMER_METHOD, { name, batch });
-export const SqsConsumerEventHandler = (name: string, eventName: string) =>
-  SetMetadata(SQS_CONSUMER_EVENT_HANDLER, { name, eventName });
+
+export const SqsMessageHandler = (args: QueueNameArgument, batch?: boolean) => SetMetadata(SQS_CONSUMER_METHOD, { args, batch });
+export const SqsConsumerEventHandler = (args: QueueNameArgument, eventName: string) =>
+  SetMetadata(SQS_CONSUMER_EVENT_HANDLER, { args, eventName });

--- a/lib/sqs.module.ts
+++ b/lib/sqs.module.ts
@@ -3,10 +3,11 @@ import { DynamicModule, Global, Module, Provider, Type } from '@nestjs/common';
 import { SQS_OPTIONS } from './sqs.constants';
 import { SqsService } from './sqs.service';
 import { SqsModuleAsyncOptions, SqsModuleOptionsFactory, SqsOptions } from './sqs.types';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Global()
 @Module({
-  imports: [DiscoveryModule],
+  imports: [DiscoveryModule, ConfigModule],
   providers: [SqsService],
   exports: [SqsService],
 })
@@ -18,15 +19,16 @@ export class SqsModule {
     };
     const sqsProvider: Provider = {
       provide: SqsService,
-      // biome-ignore lint/correctness/noUnusedVariables: <ignore>
-      useFactory: (sqsOptions: SqsOptions, discover: DiscoveryService) => new SqsService(options, discover),
-      inject: [SQS_OPTIONS, DiscoveryService],
+      useFactory: (_sqsOptions: SqsOptions, discover: DiscoveryService, configService: ConfigService) => {
+        return new SqsService(options, discover, configService)
+      },
+      inject: [SQS_OPTIONS, DiscoveryService, ConfigService],
     };
 
     return {
       global: true,
       module: SqsModule,
-      imports: [DiscoveryModule],
+      imports: [DiscoveryModule, ConfigModule],
       providers: [sqsOptions, sqsProvider],
       exports: [sqsProvider],
     };
@@ -36,14 +38,14 @@ export class SqsModule {
     const asyncProviders = this.createAsyncProviders(options);
     const sqsProvider: Provider = {
       provide: SqsService,
-      useFactory: (options: SqsOptions, discover: DiscoveryService) => new SqsService(options, discover),
-      inject: [SQS_OPTIONS, DiscoveryService],
+      useFactory: (options: SqsOptions, discover: DiscoveryService, configService: ConfigService) => new SqsService(options, discover, configService),
+      inject: [SQS_OPTIONS, DiscoveryService, ConfigService],
     };
 
     return {
       global: true,
       module: SqsModule,
-      imports: [DiscoveryModule, ...(options.imports ?? [])],
+      imports: [DiscoveryModule, ConfigModule, ...(options.imports ?? [])],
       providers: [...asyncProviders, sqsProvider],
       exports: [sqsProvider],
     };

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -7,11 +7,13 @@ import { SQS_CONSUMER_EVENT_HANDLER, SQS_CONSUMER_METHOD, SQS_OPTIONS } from './
 import {
   Message,
   QueueName,
+  QueueNameArgument,
   SqsConsumerEventHandlerMeta,
   SqsConsumerMapValues,
   SqsMessageHandlerMeta,
   SqsOptions,
 } from './sqs.types';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class SqsService implements OnModuleInit, OnModuleDestroy {
@@ -24,7 +26,8 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
   public constructor(
     @Inject(SQS_OPTIONS) public readonly options: SqsOptions,
     private readonly discover: DiscoveryService,
-  ) {}
+    private readonly configService: ConfigService
+  ) { }
 
   public async onModuleInit(): Promise<void> {
     this.logger = this.options.logger ?? new Logger('SqsService', { timestamp: false });
@@ -37,11 +40,12 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
 
     this.options.consumers?.forEach((options) => {
       const { name, stopOptions, ...consumerOptions } = options;
+
       if (this.consumers.has(name)) {
         throw new Error(`Consumer already exists: ${name}`);
       }
 
-      const metadata = messageHandlers.find(({ meta }) => meta.name === name);
+      const metadata = messageHandlers.find(({ meta }) => this.getQueueNameOrThrow(meta.args) === name);
       if (!metadata) {
         this.logger.warn(`No metadata found for: ${name}`);
         return;
@@ -52,14 +56,14 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
         ...consumerOptions,
         ...(isBatchHandler
           ? {
-              handleMessageBatch: metadata.discoveredMethod.handler.bind(
-                metadata.discoveredMethod.parentClass.instance,
-              ),
-            }
+            handleMessageBatch: metadata.discoveredMethod.handler.bind(
+              metadata.discoveredMethod.parentClass.instance,
+            ),
+          }
           : { handleMessage: metadata.discoveredMethod.handler.bind(metadata.discoveredMethod.parentClass.instance) }),
       });
 
-      const eventsMetadata = eventHandlers.filter(({ meta }) => meta.name === name);
+      const eventsMetadata = eventHandlers.filter(({ meta }) => this.getQueueNameOrThrow(meta.args) === name);
       for (const eventMetadata of eventsMetadata) {
         if (eventMetadata) {
           consumer.addListener(
@@ -68,6 +72,7 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
           );
         }
       }
+
       this.consumers.set(name, { instance: consumer, stopOptions: stopOptions ?? this.globalStopOptions });
     });
 
@@ -157,5 +162,18 @@ export class SqsService implements OnModuleInit, OnModuleDestroy {
 
     const producer = this.producers.get(name);
     return producer.send(messages as any[]);
+  }
+
+  private getQueueNameOrThrow(arg?: QueueNameArgument) {
+    if (!arg) {
+      this.logger.warn('Argument for queue name not provided');
+      return '';
+    }
+
+    if (typeof arg === 'string') {
+      return arg;
+    }
+
+    return arg.name ?? this.configService.getOrThrow(arg.configKey ?? '');
   }
 }

--- a/lib/sqs.types.ts
+++ b/lib/sqs.types.ts
@@ -3,8 +3,15 @@ import type { LoggerService, ModuleMetadata, Type } from '@nestjs/common';
 import type { Consumer, ConsumerOptions, StopOptions } from 'sqs-consumer';
 import type { Producer } from 'sqs-producer';
 
+export interface SqsConsumerHandlerNameArgument {
+  name?: string;
+  configKey?: string
+}
+
 export type ProducerOptions = Parameters<typeof Producer.create>[0];
 export type QueueName = string;
+// Accepts a string for backward compatibility
+export type QueueNameArgument = QueueName | SqsConsumerHandlerNameArgument;
 
 export type SqsConsumerOptions = Omit<ConsumerOptions, 'handleMessage' | 'handleMessageBatch'> & {
   name: QueueName;
@@ -48,11 +55,11 @@ export interface Message<T = any> {
 }
 
 export interface SqsMessageHandlerMeta {
-  name: string;
+  args: QueueNameArgument;
   batch?: boolean;
 }
 
 export interface SqsConsumerEventHandlerMeta {
-  name: string;
+  args: QueueNameArgument;
   eventName: string;
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.8.3",
     "@nestjs/common": "^11.0.6",
+    "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.6",
     "@nestjs/testing": "^11.0.6",
     "prettier": "^3.3.2",
@@ -44,7 +45,8 @@
   "peerDependencies": {
     "@aws-sdk/client-sqs": "^3.600.0",
     "@nestjs/common": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
-    "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+    "@nestjs/core": "^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+    "@nestjs/config": "^0.6.0 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "packageManager": "pnpm@9.5.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@nestjs/common':
         specifier: ^11.0.6
         version: 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      '@nestjs/config':
+        specifier: ^4.0.0
+        version: 4.0.2(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)
       '@nestjs/core':
         specifier: ^11.0.6
         version: 11.0.6(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -199,50 +202,34 @@ packages:
   '@biomejs/cli-darwin-arm64@1.8.3':
     resolution: {integrity: sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [darwin]
 
   '@biomejs/cli-darwin-x64@1.8.3':
     resolution: {integrity: sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [darwin]
 
   '@biomejs/cli-linux-arm64-musl@1.8.3':
     resolution: {integrity: sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
 
   '@biomejs/cli-linux-arm64@1.8.3':
     resolution: {integrity: sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [linux]
 
   '@biomejs/cli-linux-x64-musl@1.8.3':
     resolution: {integrity: sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
 
   '@biomejs/cli-linux-x64@1.8.3':
     resolution: {integrity: sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [linux]
 
   '@biomejs/cli-win32-arm64@1.8.3':
     resolution: {integrity: sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==}
     engines: {node: '>=14.21.3'}
-    cpu: [arm64]
-    os: [win32]
 
   '@biomejs/cli-win32-x64@1.8.3':
     resolution: {integrity: sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==}
     engines: {node: '>=14.21.3'}
-    cpu: [x64]
-    os: [win32]
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -251,140 +238,94 @@ packages:
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
 
   '@esbuild/android-arm@0.21.5':
     resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
     engines: {node: '>=12'}
-    cpu: [arm]
-    os: [android]
 
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
 
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
 
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
 
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
 
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
 
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
 
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
 
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
 
   '@esbuild/linux-x64@0.21.5':
     resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
 
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
 
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
 
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
 
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
 
   '@golevelup/nestjs-discovery@4.0.3':
     resolution: {integrity: sha512-8w3CsXHN7+7Sn2i419Eal1Iw/kOjAd6Kb55M/ZqKBBwACCMn4WiEuzssC71LpBMI1090CiDxuelfPRwwIrQK+A==}
@@ -433,6 +374,12 @@ packages:
         optional: true
       class-validator:
         optional: true
+
+  '@nestjs/config@4.0.2':
+    resolution: {integrity: sha512-McMW6EXtpc8+CwTUwFdg6h7dYcBUpH5iUILCclAsa+MbCEvC9ZKu4dCHRlJqALuhjLw97pbQu62l4+wRwGeZqA==}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      rxjs: ^7.1.0
 
   '@nestjs/core@11.0.6':
     resolution: {integrity: sha512-Xf33bwc3waAJ/faJBW06+Dwq3m15p3wbFOc/CcK8ua5EZna4sMjIjXXAb6bQmEjR1KfTXV5z595UD2vwp6cyHg==}
@@ -497,83 +444,51 @@ packages:
 
   '@rollup/rollup-android-arm-eabi@4.18.1':
     resolution: {integrity: sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==}
-    cpu: [arm]
-    os: [android]
 
   '@rollup/rollup-android-arm64@4.18.1':
     resolution: {integrity: sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==}
-    cpu: [arm64]
-    os: [android]
 
   '@rollup/rollup-darwin-arm64@4.18.1':
     resolution: {integrity: sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==}
-    cpu: [arm64]
-    os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.18.1':
     resolution: {integrity: sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==}
-    cpu: [x64]
-    os: [darwin]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.18.1':
     resolution: {integrity: sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==}
-    cpu: [arm]
-    os: [linux]
 
   '@rollup/rollup-linux-arm-musleabihf@4.18.1':
     resolution: {integrity: sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==}
-    cpu: [arm]
-    os: [linux]
 
   '@rollup/rollup-linux-arm64-gnu@4.18.1':
     resolution: {integrity: sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==}
-    cpu: [arm64]
-    os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.18.1':
     resolution: {integrity: sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==}
-    cpu: [arm64]
-    os: [linux]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.18.1':
     resolution: {integrity: sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==}
-    cpu: [ppc64]
-    os: [linux]
 
   '@rollup/rollup-linux-riscv64-gnu@4.18.1':
     resolution: {integrity: sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==}
-    cpu: [riscv64]
-    os: [linux]
 
   '@rollup/rollup-linux-s390x-gnu@4.18.1':
     resolution: {integrity: sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==}
-    cpu: [s390x]
-    os: [linux]
 
   '@rollup/rollup-linux-x64-gnu@4.18.1':
     resolution: {integrity: sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==}
-    cpu: [x64]
-    os: [linux]
 
   '@rollup/rollup-linux-x64-musl@4.18.1':
     resolution: {integrity: sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==}
-    cpu: [x64]
-    os: [linux]
 
   '@rollup/rollup-win32-arm64-msvc@4.18.1':
     resolution: {integrity: sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==}
-    cpu: [arm64]
-    os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.18.1':
     resolution: {integrity: sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==}
-    cpu: [ia32]
-    os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.18.1':
     resolution: {integrity: sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==}
-    cpu: [x64]
-    os: [win32]
 
   '@smithy/abort-controller@3.1.1':
     resolution: {integrity: sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==}
@@ -885,6 +800,14 @@ packages:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
 
+  dotenv-expand@12.0.1:
+    resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.7:
+    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -938,7 +861,6 @@ packages:
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -1946,6 +1868,14 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
 
+  '@nestjs/config@4.0.2(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1))(rxjs@7.8.1)':
+    dependencies:
+      '@nestjs/common': 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1)
+      dotenv: 16.4.7
+      dotenv-expand: 12.0.1
+      lodash: 4.17.21
+      rxjs: 7.8.1
+
   '@nestjs/core@11.0.6(@nestjs/common@11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1))(reflect-metadata@0.2.2)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 11.0.6(reflect-metadata@0.2.2)(rxjs@7.8.1)
@@ -2444,6 +2374,12 @@ snapshots:
   deep-eql@5.0.2: {}
 
   diff@4.0.2: {}
+
+  dotenv-expand@12.0.1:
+    dependencies:
+      dotenv: 16.4.7
+
+  dotenv@16.4.7: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
 Add support for resolving queue names from ConfigService using the `configKey` parameter in decorators. This allows queue names to be configured via environment variables instead of hardcoding them.

Changes:
- [x] Add @nestjs/config as peer dependency
- [x] Import ConfigModule in SqsModule to provide ConfigService
- [x] Add getQueueNameOrThrow to support both direct names and config keys
- [x] Extend QueueNameArgument type to accept { name?, configKey? }
- [x] Add test coverage for configKey-based queue resolution

Example usage:
```
  @SqsMessageHandler({ configKey: 'QUEUE_NAME_ENV_VAR' })
  async handleMessage(message: Message) { ... }
  ```

Backward compatible: existing string-based queue names continue to work.